### PR TITLE
Require Forge version 14.23.5.2824 or later. Closes #96

### DIFF
--- a/src/main/java/com/mcmoddev/communitymod/CommunityMod.java
+++ b/src/main/java/com/mcmoddev/communitymod/CommunityMod.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.*;
 
-@Mod(modid = CommunityGlobals.MOD_ID, name = "Community Mod", version = "@VERSION@", certificateFingerprint = "@FINGERPRINT@")
+@Mod(modid = CommunityGlobals.MOD_ID, name = "Community Mod", version = "@VERSION@", certificateFingerprint = "@FINGERPRINT@", dependencies = "required:forge@[14.23.5.2824,);")
 public class CommunityMod {
     
     public static final Logger LOGGER = LogManager.getLogger("Community Mod");


### PR DESCRIPTION
This is done exactly how it is shown in the @Mod javadoc.
This PR prevents players from running the mod with an older version of Forge than we compile against: 14.23.5.2824 by including "required:forge..." in the @Mod annotation of the main class.